### PR TITLE
Assess artifact dir

### DIFF
--- a/lib/commands/deploy.mjs
+++ b/lib/commands/deploy.mjs
@@ -11,8 +11,8 @@ import {AwsKeyPairValidator} from "../services/aws/aws_key_pair_validator.mjs";
 import {AwsCredentialsValidator} from "../services/aws/aws_credentials_validator.mjs";
 import {decoratedError, ErrorType} from "../browserup_errors.mjs";
 import {LogSpinner} from "../utils/log_spinner.mjs";
-import { checkLocalPortsAreFree } from "../utils/check_local_ports_are_free.mjs";
-import { EOL } from 'node:os'
+import {checkLocalPortsAreFree} from "../utils/check_local_ports_are_free.mjs";
+import {EOL} from 'node:os'
 import DockerClient from "../services/docker_client.mjs";
 
 export async function deploy(options, _programOpts) {

--- a/lib/commands/init.mjs
+++ b/lib/commands/init.mjs
@@ -3,25 +3,6 @@ import fs from 'fs';
 import path from 'path';
 import ejs from 'ejs';
 import {getAbsolutePathFromRelativeToRoot} from "../utils/path_utils.mjs";
-import {isSystemDirectory} from "../commands/path_detect.mjs";
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
-import {getDirectorySize} from "../commands/detect_dir_size.mjs"
-const filename = fileURLToPath(import.meta.url);
-const directoryName = dirname(filename);
-const MAX_DIR_SIZE = 200*124*124
-
-let isSysDir = isSystemDirectory(directoryName);
-if(isSysDir == true){
-    console.log("WARNING. You are currently in a system directory(ex: /bin,sys32), please switch to a subdirectory before proceeding.");
-    process.exit(1);
-}
-let directorySize= getDirectorySize(directoryName);
-
-if(directorySize>MAX_DIR_SIZE){
-    console.log("WARNING. The current directory exceeds 200MB in size. Please ensure that you are using the correct directory.");
-    process.exit(1);
-}
 
 
 // const TEST_TYPES = ['postman', 'curl', 'java', 'ruby', 'python', 'playwright-js', 'playwright-python', 'selenium-ruby', 'selenium-java', 'selenium-python', 'custom']; // Replace with your actual TEST_TYPES values

--- a/lib/commands/install.mjs
+++ b/lib/commands/install.mjs
@@ -1,7 +1,7 @@
 import  {DockerClient} from "../services/docker_client.mjs";
 import semver from 'semver'; // Use semver for comparing versions
-import { BrowserUpPaths} from "../utils/browserup_paths.mjs";
-import { copyFilesToDotFolderIfMissing } from "../utils/docker.mjs";
+import {BrowserUpPaths} from "../utils/browserup_paths.mjs";
+import {copyFilesToDotFolderIfMissing} from "../utils/docker.mjs";
 import chalk from "chalk";
 import {BROWSERUP_DEFAULT_IMAGE} from "../constants.mjs";
 const MINIMUM_DOCKER_VERSION= "19.0.0"

--- a/lib/commands/path_detect.mjs
+++ b/lib/commands/path_detect.mjs
@@ -39,9 +39,8 @@ export function isSystemDirectory(dirPath) {
       '/srv/'
     ];
   
-    // Combine both lists
+
     const systemDirs = windowsSystemDirs.concat(linuxSystemDirs);
   
-    // Check if the directory path is an exact match to any known system directory
     return systemDirs.includes(dirPath);
   }

--- a/lib/commands/start.mjs
+++ b/lib/commands/start.mjs
@@ -14,7 +14,6 @@ import {calculateSHA256Hash} from "../utils/hash_utils.mjs";
 import FormData from "form-data";
 import {getDirectorySize} from "../commands/detect_dir_size.mjs"
 import {isSystemDirectory} from "../commands/path_detect.mjs";
-import { exit } from "process";
 const MAX_DIR_SIZE = 200*124*124
 
 
@@ -28,7 +27,7 @@ export async function start(options, programOpts) {
     log.info(`Starting scenario ${scenarioName}...`);
 
     let credentials;
-    if (options.redeploy) {cd
+    if (options.redeploy) {
         await destroy(options);
     }
 
@@ -101,18 +100,17 @@ async function uploadArtifacts(apiToken, scenario, workingDir) {
     }
     
     
-
 async function assessArtifactDirectoryValidity(artifact_dir)  {
     let directorySize= getDirectorySize(artifact_dir);
     let isSysDir = isSystemDirectory(artifact_dir);
 
 
-    if(directorySize>MAX_DIR_SIZE){
+    if (directorySize > MAX_DIR_SIZE){
         log.info("WARNING. The current directory exceeds 200MB in size. Please ensure that you are using the correct directory.");
         process.exit(1);
     }
    
-    if(isSysDir == true){
+    if (isSysDir == true){
         log.info("WARNING. You are currently in a system directory(ex: /bin,sys32), please switch to a subdirectory before proceeding.");
         process.exit(1);
     }
@@ -177,5 +175,4 @@ async function getArtifactStatus(apiToken, artifactDir, sha) {
         });
     }
 }
-
 }

--- a/lib/commands/start.mjs
+++ b/lib/commands/start.mjs
@@ -12,9 +12,15 @@ import {decoratedError, ErrorType} from "../browserup_errors.mjs";
 import {WebConsoleClient} from "../services/webconsole_client.mjs";
 import {calculateSHA256Hash} from "../utils/hash_utils.mjs";
 import FormData from "form-data";
+import {getDirectorySize} from "../commands/detect_dir_size.mjs"
+import {isSystemDirectory} from "../commands/path_detect.mjs";
+import { exit } from "process";
+const MAX_DIR_SIZE = 200*124*124
+
 
 export async function start(options, programOpts) {
-    log.info("Running Start");
+    
+    log.info("Running Start!");
     const configRepo = new ConfigRepository(programOpts.config);
     const scenarioName = configRepo.config.model.scenario.name;
     const config = configRepo.config;
@@ -22,7 +28,7 @@ export async function start(options, programOpts) {
     log.info(`Starting scenario ${scenarioName}...`);
 
     let credentials;
-    if (options.redeploy) {
+    if (options.redeploy) {cd
         await destroy(options);
     }
 
@@ -89,10 +95,30 @@ async function uploadArtifacts(apiToken, scenario, workingDir) {
         if (profile.artifactDir) {
             log.debug(`Uploading artifact for profile: ${profile.name}`)
             const artifactDir = path.join(workingDir, profile.artifactDir);
+            assessArtifactDirectoryValidity(artifactDir)
             profile.artifactSha = await uploadArtifactIfNeeded(apiToken, artifactDir);
         }
     }
+    
+    
+
+async function assessArtifactDirectoryValidity(artifact_dir)  {
+    let directorySize= getDirectorySize(artifact_dir);
+    let isSysDir = isSystemDirectory(artifact_dir);
+
+
+    if(directorySize>MAX_DIR_SIZE){
+        log.info("WARNING. The current directory exceeds 200MB in size. Please ensure that you are using the correct directory.");
+        process.exit(1);
+    }
+   
+    if(isSysDir == true){
+        log.info("WARNING. You are currently in a system directory(ex: /bin,sys32), please switch to a subdirectory before proceeding.");
+        process.exit(1);
+    }
+    return;
 }
+
 
 async function uploadArtifactIfNeeded(apiToken, artifactDir) {
     const zippedFilepath = await zipArtifactDir(artifactDir);
@@ -152,3 +178,4 @@ async function getArtifactStatus(apiToken, artifactDir, sha) {
     }
 }
 
+}

--- a/lib/commands/stop.mjs
+++ b/lib/commands/stop.mjs
@@ -1,5 +1,5 @@
 import {destroy} from "./destroy.mjs";
-import { ErrorType, decoratedError } from "../browserup_errors.mjs";
+import {ErrorType, decoratedError} from "../browserup_errors.mjs";
 import {ClusterCredentialsRepository} from "../services/cluster_credentials_repository.mjs";
 import {ExistingClusterValidator} from "../services/existing_cluster_validator.mjs";
 import {RemoteRuns} from "../services/remote_runs.mjs";

--- a/lib/commands/upgrade.mjs
+++ b/lib/commands/upgrade.mjs
@@ -3,7 +3,7 @@ import {ClusterCredentialsRepository} from "../services/cluster_credentials_repo
 import {AwsClusterPilot} from "../services/aws/aws_cluster_pilot.mjs";
 import {LocalClusterPilot} from "../services/local_cluster_pilot.mjs";
 import {BrowserUpCli, SERVICES_VERSION} from "../browserup_cli.mjs";
-import { ServicesVersion} from "../utils/services_version.mjs";
+import {ServicesVersion} from "../utils/services_version.mjs";
 import {decoratedError, ErrorType} from "../browserup_errors.mjs";
 
 export async function upgrade(options, _programOpts) {

--- a/lib/commands/verify.mjs
+++ b/lib/commands/verify.mjs
@@ -5,12 +5,12 @@ const REQUEST_HEALTHCHECK_CMD = "curl localhost:48088/healthcheck"
 const BROWSERUP_ARTIFACT_DIR = "/home/browserup/artifact/"
 
 import path from "path";
-import { DockerClient } from "../services/docker_client.mjs";
+import {DockerClient} from "../services/docker_client.mjs";
 import retry from 'async-await-retry';
 import fs from 'fs';
-import { DataBanksLoader } from "../services/databanks_loader.mjs";
-import { RepositoryAndTag } from "../models/repository_and_tag.mjs";
-import { ErrorType, decoratedError } from "../browserup_errors.mjs";
+import {DataBanksLoader} from "../services/databanks_loader.mjs";
+import {RepositoryAndTag} from "../models/repository_and_tag.mjs";
+import {ErrorType, decoratedError} from "../browserup_errors.mjs";
 import {TokenGenerator} from "../utils/token_generator.mjs";
 import {BROWSERUP_DEFAULT_IMAGE} from "../constants.mjs";
 import {Retry} from "../utils/retry.mjs";

--- a/lib/commands/watch.mjs
+++ b/lib/commands/watch.mjs
@@ -1,4 +1,4 @@
-import { RunWatcher } from "../watch/load/run_watcher.mjs";
+import {RunWatcher} from "../watch/load/run_watcher.mjs";
 
 export async function watch(options, _programOpts) {
     const watcher = new RunWatcher(options);


### PR DESCRIPTION
Removed logic for assessing artifact directory from init.mjs and placed it into a new function that is called in start.mjs.

Deleted unneeded comments from path_detect.mjs.