### PR TITLE
Preinstall check

### DIFF
--- a/lib/browserup_cli.mjs
+++ b/lib/browserup_cli.mjs
@@ -47,6 +47,7 @@ global.log ||= log;
 import path from 'path';
 import { fileURLToPath } from 'url';
 import {LogSpinner} from "./utils/log_spinner.mjs";
+import {readFileSync} from "fs";
 
 global.appRoot = path.dirname(fileURLToPath(import.meta.url));
 
@@ -126,6 +127,16 @@ export class BrowserUpCli {
 
     }
 
+    getVersion() {
+        const packageJsonPath = path.resolve(global.appRoot, '../package.json');
+        const packageJsonData = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+        return packageJsonData.version;
+    }
+
+    versionMessage() {
+        return `BrowserUp CLI ${this.getVersion()}\nServices Version: ${SERVICES_VERSION}\nDefault Image: ${BROWSERUP_DEFAULT_IMAGE}`;
+    }
+
     constructor(exitOverride = false, outHsh = null) {
         this.program = new Command();
         const line = chalk.blue("============================\n");
@@ -151,7 +162,7 @@ export class BrowserUpCli {
             .option("-v, --verbose", "Enable verbose output. Disabled unless BROWSERUP_CLI_VERBOSE env variable set", false)
             .option("-a, --api-token <string>", "Your API token. Or export BROWSERUP_API_TOKEN. Required only for remote tests")
             .option("-c, --config <string>", "Path to browserup.load.yaml configuration file", "./browserup.load.yaml" )
-            .version("0.0.1", "-V, --version", "Print the version")
+            .version(this.versionMessage(), "-V, --version", "Print the version")
             .action(()=> { log.info(banner); this.program.help()});
 
         cluster

--- a/lib/models/config.mjs
+++ b/lib/models/config.mjs
@@ -128,18 +128,19 @@ export class Config {
     }
 
     static validFileSafeName(name) {
-        return /^[a-z0-9.\-_]+$/.test(name) && !(/[.\-_]{2,}|^[-_.]|[-_.]$/).test(name);
+        const fileSafeRegex = /^(?!.*\.\.)(?!.*\s)(?!.*\.$)[A-Za-z0-9_.]{2,40}[^.]$/;
+        return fileSafeRegex.test(name);
     }
 
     static validateReportName(name, errors = []) {
         if (!Config.validFileSafeName(name)) {
-            errors.push(`Invalid report name "${name}". Report name must contain lowercase letters and/or digits, may contain non-consecutive underscores, periods, and dashes, and may not begin or end with underscores, periods, or dashes.`);
+            errors.push(`Invalid report name "${name}". Report name allows only letters, numbers, underscores, periods, and dashes.`);
         }
     }
 
     static validateImageName(name, errors = []) {
         if (!Config.validFileSafeName(name)) {
-            errors.push(`Invalid image name "${name}". Image name must contain lowercase letters and/or digits, may contain non-consecutive underscores, periods, and/or dashes, and must start and end with a lowercase letter or digit.`);
+            errors.push(`Invalid image name "${name}". Report name may contain letters, numbers, underscores, periods, and dashes.`);
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "browserup",
-  "version": "1.0.14",
+  "version": "1.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browserup",
-      "version": "1.0.14",
+      "version": "1.1.24",
+      "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
         "@aws-sdk/client-auto-scaling": "^3.363.0",
@@ -10843,7 +10844,9 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserup",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "type": "module",
   "license": "AGPL-3.0",
   "homepage": "http://browserup.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserup",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "type": "module",
   "license": "AGPL-3.0",
   "homepage": "http://browserup.com",
@@ -19,7 +19,8 @@
   },
   "scripts": {
     "test": "jest",
-    "prepare": "./prepare.sh"
+    "prepare": "./prepare.sh",
+    "preinstall": "node preinstall.js"
   },
   "keywords": [
     "browserup",

--- a/preinstall.js
+++ b/preinstall.js
@@ -1,0 +1,15 @@
+import path from 'path';
+
+function isInstalledGlobally() {
+    // The global installation path will include the package name, but not node_modules.
+    // The local installation path will include node_modules.
+    // The dev development path will not include node_modules.
+    const globalPath = path.join(path.dirname(import.meta.url), '..');
+    return !globalPath.includes('node_modules');
+}
+
+if (!isInstalledGlobally()) {
+    console.warn("\x1b[31m\-> Error! browserup should be installed globally to prevent browserup's node_modules from polluting your tests. Instead use: " +  "\x1b[37m" + "npm install -g browserup");
+    console.warn('\x1b[31m\It is possible, but discouraged, to avert this check by installing with --ignore-scripts if you have a non-standard use case.\x1b[37m\n');
+    process.exit(1);
+}


### PR DESCRIPTION
This pull request adds two changes:

* Update the version output in order to put out a nicer message that includes the version of the docker containers it will use by default. This is hoped to prevent the case that we don't realize we are running an older image.
* Check for, and prevent, a non-global (local) installation

The problem with a non-global installation is that it will create a node_modules folder in the current directory. Browserup will try and upload that folder into the VU containers. The node_modules can be a couple hundred megs. Now, we _do_ want to upload the user's node_modules when have something they need for their own, so the easiest solution is to enforce a global install, which will keep our files out of the way.

